### PR TITLE
fix error "Unable to open include file: mpif.h (config.f90: 59)"

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -54,7 +54,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 
 ### GPU compilation requirements
 
-- **Compiler**: NVIDIA HPC SDK with `mpif90` compiler
+- **Compiler**: NVIDIA HPC SDK with `mpif90/nvfortran` compiler
 - **GPU architecture**: NVIDIA GPU with compute capability 6.0 or higher
 - **OpenACC**: Version 2.7 or later support required
 
@@ -63,7 +63,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 Configure `Src/arch.make` for GPU compilation:
 
 ```makefile
-export GPU_COMPILER = mpif90
+export GPU_COMPILER = mpif90  # nvfortran in some env
 GPU_FFLAGS = -acc -Minfo=accel -Mpreprocess -g -cuda -gpu=ptxinfo,cc80 -mp -O2 -DGPU_VERSION -DGPU_ALL_MODE_PARALLELIZATION
 ```
 

--- a/Manual.md
+++ b/Manual.md
@@ -54,7 +54,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 
 ### GPU compilation requirements
 
-- **Compiler**: NVIDIA HPC SDK with `mpif90/nvfortran` compiler
+- **Compiler**: NVIDIA HPC SDK with `nvfortran` compiler, or using `mpif90` wrapper
 - **GPU architecture**: NVIDIA GPU with compute capability 6.0 or higher
 - **OpenACC**: Version 2.7 or later support required
 
@@ -63,7 +63,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 Configure `Src/arch.make` for GPU compilation:
 
 ```makefile
-export GPU_COMPILER = mpif90  # nvfortran in some env
+export GPU_COMPILER = nvfortran # Or using `mpif90` wrapper
 GPU_FFLAGS = -acc -Minfo=accel -Mpreprocess -g -cuda -gpu=ptxinfo,cc80 -mp -O2 -DGPU_VERSION -DGPU_ALL_MODE_PARALLELIZATION
 ```
 

--- a/Manual.md
+++ b/Manual.md
@@ -54,7 +54,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 
 ### GPU compilation requirements
 
-- **Compiler**: NVIDIA HPC SDK with `nvfortran` compiler
+- **Compiler**: NVIDIA HPC SDK with `mpif90` compiler
 - **GPU architecture**: NVIDIA GPU with compute capability 6.0 or higher
 - **OpenACC**: Version 2.7 or later support required
 
@@ -63,7 +63,7 @@ FourPhonon supports GPU acceleration using OpenACC directives for NVIDIA GPUs. T
 Configure `Src/arch.make` for GPU compilation:
 
 ```makefile
-export GPU_COMPILER = nvfortran
+export GPU_COMPILER = mpif90
 GPU_FFLAGS = -acc -Minfo=accel -Mpreprocess -g -cuda -gpu=ptxinfo,cc80 -mp -O2 -DGPU_VERSION -DGPU_ALL_MODE_PARALLELIZATION
 ```
 

--- a/Src/arch.make
+++ b/Src/arch.make
@@ -2,7 +2,7 @@
 
 # Compiler
 export CPU_COMPILER = mpiifort
-export GPU_COMPILER = mpif90
+export GPU_COMPILER = mpif90  # nvfortran in some env
 
 # CPU and GPU FFLAGS
 CPU_FFLAGS = -qopenmp -traceback -O2 -fpp -DCPU_VERSION  #-static_intel   -debug 
@@ -18,7 +18,10 @@ LDFLAGS = -lsymspg
 LDFLAGS += -latomic
 export LDFLAGS
 
-MKLROOT = please find with "echo $MKLROOT"
+# Set MKLROOT manually if it's not in your environment:
+# MKLROOT = /path/to/your/mkl
+# You can find it with "echo $MKLROOT"
+
 MKL = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a -Wl,--start-group \
       $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a \
       $(MKLROOT)/lib/intel64/libmkl_sequential.a \

--- a/Src/arch.make
+++ b/Src/arch.make
@@ -2,7 +2,7 @@
 
 # Compiler
 export CPU_COMPILER = mpiifort
-export GPU_COMPILER = nvfortran
+export GPU_COMPILER = mpif90
 
 # CPU and GPU FFLAGS
 CPU_FFLAGS = -qopenmp -traceback -O2 -fpp -DCPU_VERSION  #-static_intel   -debug 
@@ -18,6 +18,7 @@ LDFLAGS = -lsymspg
 LDFLAGS += -latomic
 export LDFLAGS
 
+MKLROOT = please find with "echo $MKLROOT"
 MKL = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a -Wl,--start-group \
       $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a \
       $(MKLROOT)/lib/intel64/libmkl_sequential.a \

--- a/Src/arch.make
+++ b/Src/arch.make
@@ -2,7 +2,7 @@
 
 # Compiler
 export CPU_COMPILER = mpiifort
-export GPU_COMPILER = mpif90  # nvfortran in some env
+export GPU_COMPILER = nvfortran  # Or using `mpif90` wrapper
 
 # CPU and GPU FFLAGS
 CPU_FFLAGS = -qopenmp -traceback -O2 -fpp -DCPU_VERSION  #-static_intel   -debug 


### PR DESCRIPTION
Dear FourPhonon developers,

I attempted to compile the GPU version of FourPhonon on an RTX 5090 system using NVIDIA-HPC SDK 25.11 with CUDA 13.0. According to the documentation, `nvfortran` is recommended as the compiler. However, when compiling with nvfortran, I encountered the following error:
```
Unable to open include file: mpif.h (config.f90:59)
```
After changing
`GPU_COMPILER = nvfortran`
to
`GPU_COMPILER = mpif90`,
the compilation completed successfully without errors.

In addition, when using the GPU version, the Intel compiler environment is not loaded. Therefore, I would suggest adding an option to explicitly specify the `MKLROOT` path to avoid potential issues related to MKL detection.

Thank you very much for your work on FourPhonon.

Best regards,
Hao-Jen You