### PR TITLE
Fix output array initialization in Ind_driver

### DIFF
--- a/Src/processes.f90
+++ b/Src/processes.f90
@@ -603,11 +603,16 @@ module processes
       allocate(WP3_minus_reduce(Nbands*Nlist))
       !  end allocate reduced output arrays
 
-      ! initialize the output arrays, actrally not necessary
+      ! initialize the output arrays
       WP3_plus=0.d0
       WP3_minus=0.d0
+      Indof2ndPhonon_plus=0
+      Indof3rdPhonon_plus=0
+      Indof2ndPhonon_minus=0
+      Indof3rdPhonon_minus=0
+      Gamma_plus=0.d0
+      Gamma_minus=0.d0
       !   end initialize the output arrays
-
 
       ! initialize the reduced output arrays
       rate_scatt_plus_reduce=0.d0
@@ -3138,7 +3143,7 @@ module processes
       Ntotal_plusminus=sum(N_plusminus)
       Ntotal_minusminus=sum(N_minusminus)
 
-      ! initialize the output arrays, actrally not necessary
+      ! initialize the output arrays
       Indof2ndPhonon_plusplus=0
       Indof3rdPhonon_plusplus=0
       Indof4thPhonon_plusplus=0
@@ -3646,7 +3651,7 @@ module processes
       allocate(rate_scatt_minusminus_reduce(Nbands*Nlist))
       !  end allocate reduced output arrays
 
-      ! initialize the output arrays, actrally not necessary
+      ! initialize the output arrays
       Indof2ndPhonon_plusplus=0
       Indof3rdPhonon_plusplus=0
       Indof4thPhonon_plusplus=0
@@ -5211,7 +5216,7 @@ module processes
 
       integer(kind=4) :: chunkstart, chunkend, chunkid ! for parallel computing
 
-      ! initialize the output arrays, actrally not necessary
+      ! initialize the output arrays
       rate_scatt_4ph=0.d00
       rate_scatt_plusplus=0.d00
       rate_scatt_plusminus=0.d00


### PR DESCRIPTION
### Re-initialize output arrays in `Ind_driver` to prevent accumulation across temperatures

For multi-temperature calculations (`T_min`, `T_max`, `T_step`) with `convergence = .TRUE.`, a segmentation fault occurred when starting the iterative calculation for the second temperature.

In `processes.f90`, the `Ind_driver` subroutine assembles
`Indof2ndPhonon_plus`, `Indof3rdPhonon_plus`, `Indof2ndPhonon_minus`, `Indof3rdPhonon_minus`,
`Gamma_plus`, and `Gamma_minus`. These arrays were allocated once before the temperature loop in `ShengBTE.f90` and passed into `Ind_driver` in each temperature iteration.

Previously, these output arrays were not zeroed at the start of `Ind_driver`, which was fine for the first temperature as the arrays were freshly allocated and zero-initialized. However, on subsequent temperatures the arrays still contained values from the previous temperature, causing the `MPI_SUM` reduction to accumulate new values on top of old ones, producing corrupted phonon process indices.  This fix adds explicit zeroing at the start of `Ind_driver`.