### PR TITLE
Fix total_process overflow by casting as int64

### DIFF
--- a/Src/processes.f90
+++ b/Src/processes.f90
@@ -2489,7 +2489,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8)
        ! ----------- end sampling method add -----------
  
        do ii=0,Ngrid(1)-1       ! G1 direction
@@ -2577,7 +2577,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8)
        ! ----------- end sampling method add -----------
  
        do ii=0,Ngrid(1)-1     ! G1 direction
@@ -2665,7 +2665,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8)
        ! ----------- end sampling method add -----------
  
  
@@ -4828,7 +4828,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+    total_process = (((INT(Nbands,8) * INT(nptk,8)) * INT(Nbands,8)) * INT(nptk,8)) * INT(Nbands,8)
     ! ----------- end sampling method add -----------
  
  
@@ -4947,7 +4947,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+    total_process = INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8)
     ! ----------- end sampling method add -----------
  
  
@@ -5068,7 +5068,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
+    total_process = INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8) * INT(nptk,8) * INT(Nbands,8)
     ! ----------- end sampling method add -----------
  
  

--- a/Src/processes.f90
+++ b/Src/processes.f90
@@ -2489,7 +2489,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = Nbands*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
        ! ----------- end sampling method add -----------
  
        do ii=0,Ngrid(1)-1       ! G1 direction
@@ -2577,7 +2577,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = Nbands*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
        ! ----------- end sampling method add -----------
  
        do ii=0,Ngrid(1)-1     ! G1 direction
@@ -2665,7 +2665,7 @@ module processes
        ! ----------- sampling method add -----------
        integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
        real :: rand_matrix(num_sample_process_4ph_phase_space*5)
-       total_process = Nbands*nptk*Nbands*nptk*Nbands
+       total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
        ! ----------- end sampling method add -----------
  
  
@@ -4828,7 +4828,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = Nbands*nptk*Nbands*nptk*Nbands
+    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
     ! ----------- end sampling method add -----------
  
  
@@ -4947,7 +4947,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = Nbands*nptk*Nbands*nptk*Nbands
+    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
     ! ----------- end sampling method add -----------
  
  
@@ -5068,7 +5068,7 @@ module processes
     ! ----------- sampling method add -----------
     integer(kind=8) :: rand_num, iter, total_process, matrix_iter, temp_int
     real :: rand_matrix(num_sample_process_4ph*5)
-    total_process = Nbands*nptk*Nbands*nptk*Nbands
+    total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands
     ! ----------- end sampling method add -----------
  
  


### PR DESCRIPTION
### Fix integer overflow in `total_process` computation for 4-phonon sampling subroutines

In `processes.f90`, six subroutines compute `total_process` as:

     total_process = Nbands*nptk*Nbands*nptk*Nbands

Although `total_process` is declared `integer(kind=8)`, the right-hand side is evaluated entirely in `integer(kind=4)` before assignment. For larger q-grids, `total_process` can overflow `int32` (max ~2.1e9). For example, a 2-atom cell (6 bands) with a 16x16x16 q-point grid gives a true value of ~3.6e9, which wraps to -671,088,640, producing negative or incorrect phonon process counts.

This bug affects all six sampling subroutines: `NP_plusplus_sample`, `NP_plusminus_sample`, and `NP_minusminus_sample` (for phase space calculations), and the three corresponding `RTA_*_sample` (for Gamma calculations).

This fix promotes the RHS multiplication to 64-bit by casting the first factor before assignment:

     total_process = INT(Nbands,8)*nptk*Nbands*nptk*Nbands

> [!NOTE]
This bug was present but not problematic in v1.1 for whatever reason. I found that [older Intel compilers (before oneAPI 2023.2.0) could silently promote this integer arithmetic to 64-bit at compile time](https://www.intel.com/content/www/us/en/developer/articles/release-notes/fortran-compiler/2023.html#inpage-nav-6-1), but compiling with -qopenmp as we do for v1.3 seems to suppress this and leads to overflow. Either way, this makes the casting explicit and should prevent it from happening in the future.