### PR TITLE
Remove null chars from international spacegroup

### DIFF
--- a/Src/symmetry.f90
+++ b/Src/symmetry.f90
@@ -112,7 +112,7 @@ contains
          clattice,cpositions,ctypes,cnatoms,symprec)
     i=spg_get_international(intertmp,clattice, cpositions,&
          ctypes,cnatoms,symprec)
-    international=intertmp(1:10)
+    international=intertmp(1:index(intertmp, C_NULL_CHAR)-1)
     nops=newnops
     ! Transform from C to Fortran order.
     do i=1,nops


### PR DESCRIPTION
### Trim null characters from spglib international symbol string

In `symmetry.f90`, `spg_get_international` returns a C null-terminated string into `intertmp`. If the symmetry group string is captured to a file via stdout redirection (e.g. `srun ... > BTE.out`), the null bytes cause the file to be treated as binary by many tools (`grep`, `awk`, `diff`), breaking standard text processing of the log file.

The previous assignment copied null bytes into the Fortran string, causing output like `C2/m^@^@^@^@^@^@` in log files since `trim()` strips spaces but not nulls.

Fix by slicing at the first `C_NULL_CHAR`:

     international = intertmp(1:index(intertmp, C_NULL_CHAR)-1)